### PR TITLE
Update restart_waiter_ut

### DIFF
--- a/tests/restart_waiter_ut.cpp
+++ b/tests/restart_waiter_ut.cpp
@@ -31,12 +31,12 @@ class FastBootHelper
 public:
     FastBootHelper(): db("STATE_DB", 0)
     {
-        db.set(FAST_REBOOT_KEY, "1");
+        db.set(FAST_REBOOT_KEY, "enable");
     }
 
     ~FastBootHelper()
     {
-        db.del({FAST_REBOOT_KEY});
+        db.set(FAST_REBOOT_KEY, "disable");
     }
 private:
     DBConnector db;


### PR DESCRIPTION
Update restart_waiter_ut to use "enable"/"disable" as values for fast-reboot entry in state-db.

This PR is similar to 742 and is dedicated to 202211.